### PR TITLE
Refresh career assets and job detail sections

### DIFF
--- a/buyers-position.html
+++ b/buyers-position.html
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Luxury Handbag and Accessories Buyer - Eco Brand Japan</title>
     <link rel="stylesheet" href="style.css" />
+    <link rel="icon" type="image/png" href="/favicon/favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" type="image/svg+xml" href="/favicon/favicon.svg" />
+    <link rel="shortcut icon" href="/favicon/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
+    <link rel="manifest" href="/favicon/site.webmanifest" />
     <link
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap"
       rel="stylesheet"
@@ -98,7 +103,25 @@
               <li>Detail-oriented, research-focused approach and luxury brand knowledge (nice to have).</li>
               <li>Valid Japan work visa with at least one year of eligibility remaining.</li>
             </ul>
-            <p class="note">Working Holiday Visa holders are not eligible. Visa renewal sponsorship is available after six months of employment.</p>
+          </article>
+
+          <article>
+            <h2>What You Need to Know</h2>
+            <ul>
+              <li><strong>Eligibility:</strong> Working Holiday Visa holders are not eligible to apply. However, we offer Visa Renewal Sponsorship after six months of work.</li>
+            </ul>
+          </article>
+
+          <article>
+            <h2>Interview Process</h2>
+            <ul>
+              <li>Video conference (initial screen).</li>
+              <li>Video conference (follow-up discussion).</li>
+              <li>In-person interview.</li>
+            </ul>
+            <p>
+              Applicants living in Tokyo will be given priority. If you plan to relocate to the Greater Tokyo Area, please mention it in your cover letter.
+            </p>
           </article>
 
           <article>

--- a/career.html
+++ b/career.html
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Careers at Eco Brand Japan</title>
     <link rel="stylesheet" href="style.css" />
+    <link rel="icon" type="image/png" href="/favicon/favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" type="image/svg+xml" href="/favicon/favicon.svg" />
+    <link rel="shortcut icon" href="/favicon/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
+    <link rel="manifest" href="/favicon/site.webmanifest" />
     <link
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap"
       rel="stylesheet"
@@ -76,6 +81,15 @@
             <article class="intro-card">
               <h2>Why Work with Us</h2>
               <ul>
+                <li>
+                  Shakai Hoken social packages covering:
+                  <ul>
+                    <li>Pension (Nenkin)</li>
+                    <li>Health Insurance</li>
+                    <li>Work Insurance</li>
+                    <li>Work-related Accident Insurance</li>
+                  </ul>
+                </li>
                 <li>Structured onboarding, mentorship and regular development check-ins.</li>
                 <li>Visa renewal sponsorship and relocation support after six months of proven performance.</li>
                 <li>Global exposure through live retail, livestream selling and marketing initiatives.</li>

--- a/inventory-logistics-specialist.html
+++ b/inventory-logistics-specialist.html
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Inventory &amp; Logistics Specialist - Eco Brand Japan</title>
     <link rel="stylesheet" href="style.css" />
+    <link rel="icon" type="image/png" href="/favicon/favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" type="image/svg+xml" href="/favicon/favicon.svg" />
+    <link rel="shortcut icon" href="/favicon/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
+    <link rel="manifest" href="/favicon/site.webmanifest" />
     <link
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap"
       rel="stylesheet"
@@ -42,7 +47,7 @@
     <main class="job-detail">
       <section class="job-hero">
         <div class="container">
-          <p class="job-meta">Full-time &middot; Shinagawa, Tokyo</p>
+          <p class="job-meta">Full-time &middot; Tokyo, Japan</p>
           <h1>Inventory &amp; Logistics Specialist</h1>
           <p class="job-summary">
             Oversee authentication, stock accuracy and end-to-end logistics so every
@@ -137,7 +142,27 @@
               <li>Proficiency in Excel and familiarity with inventory management tools.</li>
               <li>Ability to prioritise multiple tasks in a fast-paced environment.</li>
               <li>Fluent English communication; JLPT N3 or above is a plus.</li>
+              <li>Post-college or university degree (Bachelor&#39;s or Master&#39;s) is required.</li>
             </ul>
+          </article>
+
+          <article>
+            <h2>What You Need to Know</h2>
+            <ul>
+              <li><strong>Eligibility:</strong> Working Holiday Visa holders are not eligible to apply. However, we offer Visa Renewal Sponsorship after six months of work.</li>
+            </ul>
+          </article>
+
+          <article>
+            <h2>Interview Process</h2>
+            <ul>
+              <li>Video conference (initial screen).</li>
+              <li>Video conference (follow-up discussion).</li>
+              <li>In-person interview.</li>
+            </ul>
+            <p>
+              Applicants living in Tokyo will be given priority. If you plan to relocate to the Greater Tokyo Area, please mention it in your cover letter.
+            </p>
           </article>
 
           <article>

--- a/product-photographer.html
+++ b/product-photographer.html
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Product Photographer - Eco Brand Japan</title>
     <link rel="stylesheet" href="style.css" />
+    <link rel="icon" type="image/png" href="/favicon/favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" type="image/svg+xml" href="/favicon/favicon.svg" />
+    <link rel="shortcut icon" href="/favicon/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
+    <link rel="manifest" href="/favicon/site.webmanifest" />
     <link
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap"
       rel="stylesheet"
@@ -112,6 +117,25 @@
               <li>A collaborative, creative and professional work environment.</li>
               <li>Career growth opportunities within a fast-expanding international business.</li>
             </ul>
+          </article>
+
+          <article>
+            <h2>What You Need to Know</h2>
+            <ul>
+              <li><strong>Eligibility:</strong> Working Holiday Visa holders are not eligible to apply. However, we offer Visa Renewal Sponsorship after six months of work.</li>
+            </ul>
+          </article>
+
+          <article>
+            <h2>Interview Process</h2>
+            <ul>
+              <li>Video conference (initial screen).</li>
+              <li>Video conference (follow-up discussion).</li>
+              <li>In-person interview.</li>
+            </ul>
+            <p>
+              Applicants living in Tokyo will be given priority. If you plan to relocate to the Greater Tokyo Area, please mention it in your cover letter.
+            </p>
           </article>
 
           <div class="job-detail-actions">

--- a/style.css
+++ b/style.css
@@ -431,6 +431,16 @@ footer {
   list-style: disc;
 }
 
+.intro-card ul ul {
+  margin-top: 8px;
+  padding-left: 20px;
+  list-style: circle;
+}
+
+.intro-card ul ul li {
+  margin-top: 4px;
+}
+
 .job-listings {
   padding: 40px 0 80px;
 }
@@ -453,6 +463,10 @@ footer {
   display: flex;
   flex-direction: column;
   gap: 15px;
+}
+
+.job-card .button {
+  margin-top: auto;
 }
 
 .button {
@@ -577,10 +591,6 @@ footer {
 }
 
 @media (min-width: 768px) {
-  .intro-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
   .job-card-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }


### PR DESCRIPTION
## Summary
- add favicon links to the careers and role detail pages and adjust the careers intro layout for a single-column stack
- expand "Why Work with Us" with Shakai Hoken social package details and add universal eligibility and interview process sections across job listings
- update the Inventory & Logistics role metadata and qualifications, including degree requirements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dddf3a5de0832094e382680a6109b4