### PR TITLE
Reorder hiring info sections on job listings

### DIFF
--- a/buyers-position.html
+++ b/buyers-position.html
@@ -105,25 +105,6 @@
           </article>
 
           <article>
-            <h2>What You Need to Know</h2>
-            <ul>
-              <li><strong>Eligibility:</strong> Working Holiday Visa holders are not eligible to apply. However, we offer Visa Renewal Sponsorship after six months of work.</li>
-            </ul>
-          </article>
-
-          <article>
-            <h2>Interview Process</h2>
-            <ul>
-              <li>Video conference (initial screen).</li>
-              <li>Video conference (follow-up discussion).</li>
-              <li>In-person interview.</li>
-            </ul>
-            <p>
-              Applicants living in Tokyo will be given priority. If you plan to relocate to the Greater Tokyo Area, please mention it in your cover letter.
-            </p>
-          </article>
-
-          <article>
             <h2>Main Duties &amp; Responsibilities</h2>
             <ul>
               <li>Master our product database, pricing architecture and compliance standards.</li>
@@ -171,6 +152,25 @@
               <li>Company-covered travel expenses for assignments outside Greater Tokyo, including transport, hotels and meals.</li>
               <li>Regular domestic and international travel opportunities after probation, up to 30&ndash;40% of time.</li>
             </ul>
+          </article>
+
+          <article>
+            <h2>What You Need to Know</h2>
+            <ul>
+              <li><strong>Eligibility:</strong> Working Holiday Visa holders are not eligible to apply. However, we offer Visa Renewal Sponsorship after six months of work.</li>
+            </ul>
+          </article>
+
+          <article>
+            <h2>Interview Process</h2>
+            <ul>
+              <li>Video conference (initial screen).</li>
+              <li>Video conference (follow-up discussion).</li>
+              <li>In-person interview.</li>
+            </ul>
+            <p>
+              Applicants living in Tokyo will be given priority. If you plan to relocate to the Greater Tokyo Area, please mention it in your cover letter.
+            </p>
           </article>
 
           <div class="job-detail-actions">

--- a/inventory-logistics-specialist.html
+++ b/inventory-logistics-specialist.html
@@ -151,6 +151,20 @@
           </article>
 
           <article>
+            <h2>Preferred Experience</h2>
+            <ul>
+              <li>Background in luxury consignment or resale.</li>
+              <li>Luxury authentication certifications.</li>
+              <li>Understanding of international shipping procedures and customs.</li>
+            </ul>
+          </article>
+
+          <article>
+            <h2>Physical Requirements</h2>
+            <p>Comfortable standing, moving and lifting up to 10 kg as needed.</p>
+          </article>
+
+          <article>
             <h2>What You Need to Know</h2>
             <ul>
               <li><strong>Eligibility:</strong> Working Holiday Visa holders are not eligible to apply. However, we offer Visa Renewal Sponsorship after six months of work.</li>
@@ -167,20 +181,6 @@
             <p>
               Applicants living in Tokyo will be given priority. If you plan to relocate to the Greater Tokyo Area, please mention it in your cover letter.
             </p>
-          </article>
-
-          <article>
-            <h2>Preferred Experience</h2>
-            <ul>
-              <li>Background in luxury consignment or resale.</li>
-              <li>Luxury authentication certifications.</li>
-              <li>Understanding of international shipping procedures and customs.</li>
-            </ul>
-          </article>
-
-          <article>
-            <h2>Physical Requirements</h2>
-            <p>Comfortable standing, moving and lifting up to 10 kg as needed.</p>
           </article>
 
           <div class="job-detail-actions">


### PR DESCRIPTION
## Summary
- move the "What You Need to Know" and "Interview Process" articles to the end of the buyer and inventory job listings so they appear after the role details

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddea95c04c8320acaf57076e92ce17