### PR TITLE
Update careers page logo link

### DIFF
--- a/career.html
+++ b/career.html
@@ -28,7 +28,7 @@
     <header>
       <div class="container header-container">
         <div class="logo">
-          <a href="index.html">
+          <a href="https://www.ecobrandjapan.com/">
             <img src="images/EBJ-Logo-cropped-2.png" alt="Eco Brand Japan logo" />
           </a>
         </div>


### PR DESCRIPTION
## Summary
- update the Eco Brand Japan logo link on the careers page to point to the site root instead of the index.html file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddeb92a6648320adc54aba4710b77e