### PR TITLE
Refine placeholder listings for part-time roles

### DIFF
--- a/career.html
+++ b/career.html
@@ -119,6 +119,15 @@
               <a class="button" href="buyers-position.html">View Role</a>
             </article>
             <article class="job-card">
+              <h3>Live Seller</h3>
+              <p class="job-card-meta">Part-time &middot; Tokyo, Japan</p>
+              <p>
+                Engage our community through livestream sessions and present curated
+                collections in real time. Full details will be available soon.
+              </p>
+              <a class="button" href="live-seller.html">View Role</a>
+            </article>
+            <article class="job-card">
               <h3>Inventory &amp; Logistics Specialist</h3>
               <p>
                 Keep our operations running smoothly by safeguarding product accuracy,
@@ -133,6 +142,15 @@
                 channels while maintaining our visual standards worldwide.
               </p>
               <a class="button" href="product-photographer.html">View Role</a>
+            </article>
+            <article class="job-card">
+              <h3>Social Media Operator</h3>
+              <p class="job-card-meta">Part-time &middot; Tokyo, Japan</p>
+              <p>
+                Support our digital storytelling across platforms and coordinate
+                content publishing. Full details will be available soon.
+              </p>
+              <a class="button" href="social-media-operator.html">View Role</a>
             </article>
           </div>
         </div>

--- a/live-seller.html
+++ b/live-seller.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Live Seller - Eco Brand Japan</title>
+    <link rel="stylesheet" href="style.css" />
+    <link rel="icon" type="image/png" href="/favicon/favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" type="image/svg+xml" href="/favicon/favicon.svg" />
+    <link rel="shortcut icon" href="/favicon/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
+    <link rel="manifest" href="/favicon/site.webmanifest" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <meta
+      name="description"
+      content="Live Seller position at Eco Brand Japan. Details coming soon."
+    />
+  </head>
+  <body>
+    <header>
+      <div class="container header-container">
+        <div class="logo">
+          <a href="index.html">
+            <img src="images/EBJ-Logo-cropped-2.png" alt="Eco Brand Japan logo" />
+          </a>
+        </div>
+        <button class="nav-toggle" aria-label="Toggle navigation" aria-controls="navbar">☰</button>
+        <nav id="navbar">
+          <ul>
+            <li><a href="index.html#about">About</a></li>
+            <li><a href="index.html#values">Values</a></li>
+            <li><a href="index.html#offers">Services</a></li>
+            <li><a class="current" href="career.html">Careers</a></li>
+            <li class="lang-switch"><a href="/ja/"><span class="desktop-label">日本語</span><span class="mobile-label">JP</span></a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main class="job-detail">
+      <section class="job-hero">
+        <div class="container">
+          <p class="job-meta">Part-time &middot; Tokyo, Japan</p>
+          <h1>Live Seller</h1>
+          <p class="job-summary">We are preparing the full role overview. Please check back soon for more information.</p>
+          <div class="job-actions">
+            <a class="button button-secondary" href="career.html#open-roles">Back to Careers</a>
+            <button class="button disabled" type="button" disabled aria-disabled="true">
+              Applications Opening Soon
+            </button>
+          </div>
+          <p class="job-status">Detailed responsibilities and requirements will be published shortly.</p>
+        </div>
+      </section>
+
+      <section class="job-body">
+        <div class="container job-content">
+          <article>
+            <h2>Role Overview</h2>
+            <p>We are finalising the role description. Please return soon for the complete details.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container footer-container">
+        <p>&copy; 2025 Eco Brand Japan. All rights reserved.</p>
+      </div>
+    </footer>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/social-media-operator.html
+++ b/social-media-operator.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Social Media Operator - Eco Brand Japan</title>
+    <link rel="stylesheet" href="style.css" />
+    <link rel="icon" type="image/png" href="/favicon/favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" type="image/svg+xml" href="/favicon/favicon.svg" />
+    <link rel="shortcut icon" href="/favicon/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
+    <link rel="manifest" href="/favicon/site.webmanifest" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <meta
+      name="description"
+      content="Social Media Operator position at Eco Brand Japan. Details coming soon."
+    />
+  </head>
+  <body>
+    <header>
+      <div class="container header-container">
+        <div class="logo">
+          <a href="index.html">
+            <img src="images/EBJ-Logo-cropped-2.png" alt="Eco Brand Japan logo" />
+          </a>
+        </div>
+        <button class="nav-toggle" aria-label="Toggle navigation" aria-controls="navbar">☰</button>
+        <nav id="navbar">
+          <ul>
+            <li><a href="index.html#about">About</a></li>
+            <li><a href="index.html#values">Values</a></li>
+            <li><a href="index.html#offers">Services</a></li>
+            <li><a class="current" href="career.html">Careers</a></li>
+            <li class="lang-switch"><a href="/ja/"><span class="desktop-label">日本語</span><span class="mobile-label">JP</span></a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main class="job-detail">
+      <section class="job-hero">
+        <div class="container">
+          <p class="job-meta">Part-time &middot; Tokyo, Japan</p>
+          <h1>Social Media Operator</h1>
+          <p class="job-summary">We are preparing the full role overview. Please check back soon for more information.</p>
+          <div class="job-actions">
+            <a class="button button-secondary" href="career.html#open-roles">Back to Careers</a>
+            <button class="button disabled" type="button" disabled aria-disabled="true">
+              Applications Opening Soon
+            </button>
+          </div>
+          <p class="job-status">Detailed responsibilities and requirements will be published shortly.</p>
+        </div>
+      </section>
+
+      <section class="job-body">
+        <div class="container job-content">
+          <article>
+            <h2>Role Overview</h2>
+            <p>We are finalising the role description. Please return soon for the complete details.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container footer-container">
+        <p>&copy; 2025 Eco Brand Japan. All rights reserved.</p>
+      </div>
+    </footer>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/style.css
+++ b/style.css
@@ -465,6 +465,13 @@ footer {
   gap: 15px;
 }
 
+.job-card-meta {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(0, 0, 0, 0.65);
+}
+
 .job-card .button {
   margin-top: auto;
 }


### PR DESCRIPTION
## Summary
- add placeholder Live Seller and Social Media Operator role pages so they are visible on the site
- list the new positions on the careers page with temporary descriptions and links
- mark the new roles as part-time positions in Tokyo and ensure their pages include favicon assets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddfccc2e648320a13f7152abba9c41