### PR TITLE
Add full-time job meta to career page listings

### DIFF
--- a/career.html
+++ b/career.html
@@ -112,6 +112,7 @@
           <div class="job-card-grid">
             <article class="job-card">
               <h3>Luxury Handbag and Accessories Buyer</h3>
+              <p class="job-card-meta">Full-time &middot; Tokyo, Japan</p>
               <p>
                 Source, evaluate and authenticate luxury collections while building
                 relationships with trusted partners across Japan and abroad.
@@ -129,6 +130,7 @@
             </article>
             <article class="job-card">
               <h3>Inventory &amp; Logistics Specialist</h3>
+              <p class="job-card-meta">Full-time &middot; Tokyo, Japan</p>
               <p>
                 Keep our operations running smoothly by safeguarding product accuracy,
                 coordinating shipments and supporting cross-functional projects.
@@ -137,6 +139,7 @@
             </article>
             <article class="job-card">
               <h3>Product Photographer</h3>
+              <p class="job-card-meta">Full-time &middot; Tokyo, Japan</p>
               <p>
                 Capture the craftsmanship of every piece for marketplaces and marketing
                 channels while maintaining our visual standards worldwide.


### PR DESCRIPTION
## Summary
- add full-time Tokyo job meta details to buyer, logistics, and photographer cards on the careers page to match other listings

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68ddfee3563c8320a4b4dd14d600cc09