### PR TITLE
Restyle home page to match refreshed brand theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
       }
     </style>
   </head>
-  <body>
+  <body class="home-page">
     <!-- Header and navigation -->
     <header>
       <div class="container header-container">
@@ -81,127 +81,183 @@
       </div>
     </header>
 
-    <!-- Hero section with background image from Marketing folder -->
-    <section class="hero">
-      <!-- Background image inserted as img so that mobile browsers reliably load it -->
-      <img class="hero-bg" src="images/8.jpg" alt="Luxury flatlay background" />
-      <div class="hero-content">
-        <h1>Sustainable Luxury Reimagined</h1>
-        <p>
-          Pre-owned designer bags with new life, honesty and circular vision.
-        </p>
-      </div>
-    </section>
-
-    <!-- About section -->
-    <section id="about" class="about">
-      <div class="container about-container">
-        <div class="about-text">
-          <h2>Who We Are</h2>
-          <p>
-          Founded in 2012, Eco Brand Japan sources and curates luxury
-            handbags and accessories from iconic houses like Hermès, Chanel,
-            Louis Vuitton and more, giving premium pieces a new chapter. We
-            operate within the circular economy, respecting each bag's
-            craftsmanship and ensuring authenticity at every step.
-          </p>
-          <p>
-            With a team of experienced experts, we authenticate, restore and
-            prepare items so that they can bring joy across generations. Our
-            collection is hand-selected for quality and rarity, making it
-            possible for you to own a piece of fashion history responsibly.
-          </p>
-        </div>
-        <div class="about-image">
-          <img
-            src="images/IMG_3435.jpg"
-            alt="Close-up of YSL bag from Marketing shoot"
-            loading="lazy"
-          />
-        </div>
-      </div>
-    </section>
-
-    <!-- Values section -->
-    <section id="values" class="values">
-      <div class="container values-container">
-        <h2>Our Promise</h2>
-        <div class="values-grid">
-          <div class="value">
-            <h3>Authenticity</h3>
+    <main>
+      <!-- Hero section with background image from Marketing folder -->
+      <section class="hero hero-home">
+        <!-- Background image inserted as img so that mobile browsers reliably load it -->
+        <img class="hero-bg" src="images/8.jpg" alt="Luxury flatlay background" />
+        <div class="hero-overlay" aria-hidden="true"></div>
+        <div class="container hero-content">
+          <div class="hero-intro">
+            <span class="hero-tag">Circular luxury from Tokyo</span>
+            <h1>Sustainable Luxury, Curated With Intention</h1>
             <p>
-              Every item we offer is thoroughly vetted by specialists. Our
-              commitment to transparency means you receive only genuine
-              pieces and honest descriptions.
+              We restore and reintroduce rare designer handbags so they can continue their storied journeys—authentically, responsibly and beautifully.
             </p>
-          </div>
-          <div class="value">
-            <h3>Sustainability</h3>
-            <p>
-              We believe luxury should not be disposable. By keeping
-              beautiful creations in circulation, we honour the materials and
-              craftsmanship that went into them.
-            </p>
-          </div>
-          <div class="value">
-            <h3>Respect &amp; Trust</h3>
-            <p>
-              Our relationships with suppliers and clients are built on
-              respect and trust. We aim to make buying and selling pre-owned
-              luxury a pleasant, transparent experience.
-            </p>
+            <div class="hero-actions">
+              <a class="button" href="#offers">Partner with Us</a>
+              <a class="button button-outline" href="#values">Explore Our Promise</a>
+            </div>
+            <ul class="hero-highlights">
+              <li><span>12+</span> years curating iconic maisons</li>
+              <li><span>40k</span> authenticated pieces circulated</li>
+              <li><span>Global</span> network of trusted partners</li>
+            </ul>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
 
-    <!-- Services/Offers section -->
-    <section id="offers" class="offers">
-      <div class="container offers-container">
-          <h2>How We Work</h2>
+      <!-- About section -->
+      <section id="about" class="about">
+        <div class="container about-container">
+          <div class="about-text">
+            <span class="section-tag">Who We Are</span>
+            <h2>Crafting the Next Chapter for Luxury Icons</h2>
+            <p>
+              Founded in 2012, Eco Brand Japan sources and curates handbags and accessories from maisons like Hermès, Chanel and Louis Vuitton. Each piece is handled with reverence for its craftsmanship and a commitment to longevity within the circular economy.
+            </p>
+            <p>
+              Our multilingual specialists authenticate, restore and prepare every item before it meets its next guardian. The result is a collection that marries rarity with responsibility, inviting you to invest in fashion history with confidence.
+            </p>
+            <div class="about-actions">
+              <a class="button" href="career.html">Meet the Team</a>
+              <a class="button button-outline" href="#gallery">View Highlights</a>
+            </div>
+          </div>
+          <div class="about-visual">
+            <img
+              src="images/IMG_3435.jpg"
+              alt="Close-up of YSL bag from Marketing shoot"
+              loading="lazy"
+            />
+            <div class="about-highlights">
+              <div class="highlight-card">
+                <span class="highlight-number">100%</span>
+                <p>Specialist-authenticated inventory</p>
+              </div>
+              <div class="highlight-card">
+                <span class="highlight-number">24h</span>
+                <p>Average turnaround for supplier onboarding</p>
+              </div>
+              <div class="highlight-card">
+                <span class="highlight-number">7</span>
+                <p>Languages spoken across our concierge team</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Values section -->
+      <section id="values" class="values">
+        <div class="container values-container">
+          <span class="section-tag">Our Promise</span>
+          <h2>Principles That Guide Every Partnership</h2>
+          <div class="values-grid">
+            <article class="value">
+              <span class="value-icon" aria-hidden="true">&#10024;</span>
+              <h3>Authenticity Assured</h3>
+              <p>
+                Expert authenticators, proprietary checkpoints and transparent reporting ensure each item and description is worthy of your trust.
+              </p>
+            </article>
+            <article class="value">
+              <span class="value-icon" aria-hidden="true">&#9851;</span>
+              <h3>Sustainable Stewardship</h3>
+              <p>
+                We champion circularity—from mindful restoration to responsible packaging—so luxury remains a force for good across generations.
+              </p>
+            </article>
+            <article class="value">
+              <span class="value-icon" aria-hidden="true">&#129309;</span>
+              <h3>Respectful Relationships</h3>
+              <p>
+                We build long-term partnerships rooted in clarity, integrity and care for the people who entrust us with their collections.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <!-- Services/Offers section -->
+      <section id="offers" class="offers">
+        <div class="container offers-container">
+          <div class="offers-header">
+            <span class="section-tag">How We Work</span>
+            <h2>Tailored Programmes for Suppliers &amp; Distributors</h2>
+            <p>
+              Whether you bring us collections or curate them for clients, our team orchestrates every detail—from valuation to storytelling.
+            </p>
+          </div>
           <div class="offers-grid">
-            <div class="offer">
+            <article class="offer">
               <h3>For Suppliers</h3>
               <ul>
-                <li>We purchase your inventory upfront.</li>
-                <li>Photo catalogs showcase your products to our network-created by us or by you.</li>
-                <li>In-house authentication and valuation for all stock.</li>
+                <li>Upfront purchasing with swift payment cycles.</li>
+                <li>In-house photography and catalogues ready for market.</li>
+                <li>Restoration, authentication and logistics handled end-to-end.</li>
               </ul>
-            </div>
-            <div class="offer">
+              <a class="text-link" href="mailto:info@ecobrandjapan.com">Share Your Collection</a>
+            </article>
+            <article class="offer">
               <h3>For Distributors</h3>
               <ul>
-                <li>Daily-updated catalog with tens of thousands of items by brand and category.</li>
-                <li>Expert advice on curating selections for your client segments.</li>
-                <li>Consignment options on major marketplaces and luxury retail platforms, online and in store.</li>
+                <li>Daily refreshed catalogue across iconic brands and categories.</li>
+                <li>Personalised curation and merchandising insights.</li>
+                <li>Consignment options for flagship boutiques and marketplaces.</li>
               </ul>
-            </div>
-          </div>
-      </div>
-    </section>
-
-    <!-- Gallery section to showcase product highlights -->
-    <section class="gallery">
-      <div class="container gallery-container">
-        <h2>Highlights</h2>
-        <div class="gallery-grid">
-          <div class="gallery-item">
-            <img
-              src="images/IMG_0758-Edit.jpg"
-              alt="Gray Birkin"
-              loading="lazy"
-            />
-          </div>
-          <div class="gallery-item">
-            <img
-              src="images/IMG_9065.jpg"
-              alt="Two black YSL bags from Marketing folder"
-              loading="lazy"
-            />
+              <a class="text-link" href="mailto:info@ecobrandjapan.com">Connect with Our Concierge</a>
+            </article>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
+
+      <!-- Gallery section to showcase product highlights -->
+      <section id="gallery" class="gallery">
+        <div class="container gallery-container">
+          <div class="gallery-header">
+            <span class="section-tag">Highlights</span>
+            <h2>Stories Preserved in Every Detail</h2>
+            <p>
+              Explore a glimpse of the pieces we carefully reintroduce to collectors and connoisseurs worldwide.
+            </p>
+          </div>
+          <div class="gallery-grid">
+            <figure class="gallery-item">
+              <img
+                src="images/IMG_0758-Edit.jpg"
+                alt="Gray Hermès Birkin bag on display"
+                loading="lazy"
+              />
+              <figcaption>Hermès Birkin 30 Gris Tourterelle</figcaption>
+            </figure>
+            <figure class="gallery-item">
+              <img
+                src="images/IMG_9065.jpg"
+                alt="Black YSL bags from a marketing shoot"
+                loading="lazy"
+              />
+              <figcaption>Saint Laurent classics prepared for livestream retail</figcaption>
+            </figure>
+          </div>
+        </div>
+      </section>
+
+      <section class="cta-banner">
+        <div class="container cta-banner-content">
+          <div>
+            <h2>Let&#39;s Shape the Future of Sustainable Luxury</h2>
+            <p>
+              Partner with Eco Brand Japan to breathe new life into storied accessories—or join our team to craft memorable client experiences.
+            </p>
+          </div>
+          <div class="cta-actions">
+            <a class="button" href="mailto:info@ecobrandjapan.com">Start a Conversation</a>
+            <a class="button button-outline" href="career.html">View Careers</a>
+          </div>
+        </div>
+      </section>
+    </main>
 
     <!-- Footer -->
     <footer>

--- a/style.css
+++ b/style.css
@@ -14,8 +14,8 @@
 body {
   font-family: 'Poppins', sans-serif;
   line-height: 1.6;
-  color: #333;
-  background-color: #fafafa;
+  color: #2f2a26;
+  background: linear-gradient(180deg, #f7f3ef 0%, #fdfbf8 45%, #faf5f1 100%);
 }
 
 h1 {
@@ -151,7 +151,6 @@ nav a.current {
   display: flex;
   align-items: center;
   justify-content: center;
-  text-align: center;
   padding-top: 60px; /* space for fixed header */
 }
 
@@ -169,40 +168,113 @@ nav a.current {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  z-index: -1;
-}
-
-.hero::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  /* Slightly transparent overlay to allow the dark flatlay to show through */
-  background-color: rgba(250, 250, 250, 0.1);
-  /* subtle overlay to improve text readability */
+  z-index: -2;
 }
 
 .hero-content {
   position: relative;
-  max-width: 600px;
+  width: 100%;
+  max-width: 1100px;
   padding: 0 20px;
+  display: flex;
+  justify-content: flex-start;
+}
+
+.hero-home {
+  text-align: left;
+}
+
+.hero-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+      110deg,
+      rgba(24, 19, 16, 0.82) 0%,
+      rgba(24, 19, 16, 0.6) 40%,
+      rgba(24, 19, 16, 0.35) 100%
+    );
+  z-index: -1;
+}
+
+.hero-intro {
+  display: grid;
+  gap: 22px;
+  max-width: 620px;
+  color: #fdf5ec;
 }
 
 .hero h1 {
-  font-size: 2.8rem;
+  font-size: clamp(2.6rem, 5vw, 3.6rem);
   font-weight: 600;
-  margin-bottom: 20px;
-  color: whitesmoke;
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.9)
+  margin-bottom: 0;
+  color: #fdf5ec;
+  text-shadow: 0 10px 24px rgba(0, 0, 0, 0.4);
 }
 
 .hero p {
-  font-size: 1.1rem;
-  margin-bottom: 30px;
-  color:whitesmoke;
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 1.2)
+  font-size: 1.15rem;
+  margin-bottom: 0;
+  color: rgba(255, 249, 244, 0.92);
+}
+
+.hero-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: rgba(248, 240, 232, 0.85);
+  color: var(--primary-color);
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.28);
+}
+
+.hero-tag::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent-color);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.hero-highlights {
+  display: grid;
+  gap: 10px;
+  padding: 0;
+  margin: 8px 0 0;
+  list-style: none;
+  font-size: 0.95rem;
+}
+
+.hero-highlights li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: rgba(255, 249, 244, 0.9);
+}
+
+.hero-highlights span {
+  display: inline-flex;
+  min-width: 70px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: rgba(248, 240, 232, 0.18);
+  border: 1px solid rgba(253, 245, 236, 0.35);
+  font-weight: 600;
+  color: #fdf5ec;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  justify-content: center;
 }
 
 
@@ -228,134 +300,329 @@ section {
 }
 
 /* About section */
+.about {
+  position: relative;
+}
+
 .about-container {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 40px;
+  display: grid;
+  gap: 50px;
   align-items: center;
 }
 
+@media (min-width: 992px) {
+  .about-container {
+    grid-template-columns: 1.1fr 1fr;
+  }
+}
+
+.section-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(150, 109, 74, 0.12);
+  color: var(--accent-color);
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.section-tag::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent-color);
+}
+
 .about-text {
-  flex: 1 1 300px;
+  display: grid;
+  gap: 20px;
 }
 
 .about-text h2 {
-  font-size: 2rem;
-  margin-bottom: 15px;
-  color: #2f2f2f;
+  font-size: clamp(2rem, 4vw, 2.6rem);
+  color: #2b241f;
+  font-family: 'Playfair Display', serif;
 }
 
 .about-text p {
-  margin-bottom: 15px;
-  color: #555;
+  margin: 0;
+  color: #4f443c;
 }
 
-.about-image {
-  flex: 1 1 300px;
+.about-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-top: 10px;
+}
+
+.about-visual {
+  display: grid;
+  gap: 24px;
+}
+
+.about-visual img {
+  border-radius: 20px;
+  box-shadow: 0 25px 45px rgba(0, 0, 0, 0.18);
+}
+
+.about-highlights {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.highlight-card {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 18px;
+  padding: 18px;
+  box-shadow: 0 18px 36px rgba(50, 42, 37, 0.12);
+  text-align: center;
+  display: grid;
+  gap: 6px;
+}
+
+.highlight-number {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--accent-color);
+  font-family: 'Playfair Display', serif;
+}
+
+.highlight-card p {
+  font-size: 0.9rem;
+  color: #5f534a;
 }
 
 /* Values section */
 .values {
-  background-color: #fff;
-  border-top: 1px solid #f0f0f0;
-  border-bottom: 1px solid #f0f0f0;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.85), rgba(249, 244, 239, 0.95));
+  border-top: 1px solid rgba(150, 109, 74, 0.1);
+  border-bottom: 1px solid rgba(150, 109, 74, 0.1);
+}
+
+.values-container {
+  display: grid;
+  gap: 40px;
+  text-align: center;
 }
 
 .values-container h2 {
-  text-align: center;
-  font-size: 2rem;
-  margin-bottom: 40px;
-  color: #2f2f2f;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  color: #2b241f;
+  font-family: 'Playfair Display', serif;
 }
 
 .values-grid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 30px;
+  display: grid;
+  gap: 28px;
+}
+
+@media (min-width: 900px) {
+  .values-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 }
 
 .value {
-  flex: 1 1 250px;
-  background-color: #faf7f4;
-  padding: 20px;
-  border-radius: 6px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  background: #ffffff;
+  padding: 32px 24px;
+  border-radius: 20px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.08);
+  display: grid;
+  gap: 14px;
+  align-items: start;
+}
+
+.value-icon {
+  font-size: 1.4rem;
+  color: var(--accent-color);
 }
 
 .value h3 {
-  font-size: 1.3rem;
-  margin-bottom: 10px;
+  font-size: 1.4rem;
   color: #322a25;
+  font-family: 'Playfair Display', serif;
 }
 
 .value p {
-  color: #555;
+  color: #4f443c;
 }
 
 /* Offers section */
-.offers-container h2 {
+.offers-container {
+  display: grid;
+  gap: 40px;
+}
+
+.offers-header {
+  display: grid;
+  gap: 18px;
   text-align: center;
-  font-size: 2rem;
-  margin-bottom: 40px;
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.offers-header h2 {
+  font-size: clamp(2rem, 4vw, 2.6rem);
+  color: #2b241f;
+  font-family: 'Playfair Display', serif;
+}
+
+.offers-header p {
+  color: #4f443c;
 }
 
 .offers-grid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 30px;
+  display: grid;
+  gap: 24px;
+}
+
+@media (min-width: 900px) {
+  .offers-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .offer {
-  flex: 1 1 280px;
-  background-color: #f7f5f3;
-  padding: 20px;
-  border-radius: 6px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  background: #ffffff;
+  border-radius: 20px;
+  padding: 28px;
+  box-shadow: 0 20px 45px rgba(50, 42, 37, 0.08);
+  display: grid;
+  gap: 16px;
 }
 
 .offer h3 {
-  font-size: 1.3rem;
-  margin-bottom: 10px;
+  font-size: 1.4rem;
   color: #322a25;
+  font-family: 'Playfair Display', serif;
 }
 
 .offer ul {
-  list-style: disc inside;
-  color: #555;
+  list-style: none;
+  display: grid;
+  gap: 10px;
+  padding-left: 0;
+  color: #4f443c;
 }
 
-.offer li + li {
-  margin-top: 8px;
+.offer li::before {
+  content: '•';
+  margin-right: 8px;
+  color: var(--accent-color);
+}
+
+.text-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  color: var(--accent-color);
+}
+
+.text-link::after {
+  content: '\2192';
+  transition: transform 0.2s ease;
+}
+
+.text-link:hover::after {
+  transform: translateX(4px);
 }
 
 /* Gallery section */
-.gallery-container h2 {
+.gallery-container {
+  display: grid;
+  gap: 32px;
+}
+
+.gallery-header {
   text-align: center;
-  font-size: 2rem;
-  margin-bottom: 30px;
+  display: grid;
+  gap: 16px;
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.gallery-header h2 {
+  font-size: clamp(2rem, 4vw, 2.6rem);
+  font-family: 'Playfair Display', serif;
+  color: #2b241f;
+}
+
+.gallery-header p {
+  color: #4f443c;
 }
 
 .gallery-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
 }
 
 .gallery-item {
   overflow: hidden;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  border-radius: 20px;
+  box-shadow: 0 25px 45px rgba(50, 42, 37, 0.1);
+  background: #ffffff;
+  display: grid;
 }
 
 .gallery-item img {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  transition: transform 0.3s ease;
+  transition: transform 0.35s ease;
 }
 
 .gallery-item:hover img {
   transform: scale(1.05);
+}
+
+.gallery-item figcaption {
+  padding: 18px 20px;
+  font-size: 0.95rem;
+  color: #5f534a;
+}
+
+.cta-banner {
+  background: linear-gradient(135deg, rgba(50, 42, 37, 0.92), rgba(150, 109, 74, 0.88));
+  color: #fdf5ec;
+  padding: 80px 0;
+}
+
+.cta-banner-content {
+  display: grid;
+  gap: 24px;
+  align-items: center;
+}
+
+@media (min-width: 900px) {
+  .cta-banner-content {
+    grid-template-columns: 1.2fr auto;
+  }
+}
+
+.cta-banner h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2.2rem, 5vw, 2.8rem);
+  margin-bottom: 12px;
+}
+
+.cta-banner p {
+  color: rgba(253, 245, 236, 0.92);
+  max-width: 640px;
+}
+
+.cta-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
 }
 
 /* Footer */
@@ -572,6 +839,29 @@ footer {
   cursor: not-allowed;
   transform: none;
   border-color: transparent;
+}
+
+.button-outline {
+  background: transparent;
+  color: var(--accent-color);
+  border-color: rgba(150, 109, 74, 0.6);
+}
+
+.button-outline:hover {
+  background: rgba(150, 109, 74, 0.1);
+  color: var(--accent-color-dark);
+}
+
+.hero .button-outline,
+.cta-banner .button-outline {
+  color: #fdf5ec;
+  border-color: rgba(253, 245, 236, 0.65);
+}
+
+.hero .button-outline:hover,
+.cta-banner .button-outline:hover {
+  background: rgba(253, 245, 236, 0.12);
+  color: #ffffff;
 }
 
 .job-detail {


### PR DESCRIPTION
## Summary
- redesign the home page hero, about, values, offers, and gallery sections to deliver a more elegant presentation aligned with the career page palette
- introduce new content highlights, calls-to-action, and supporting markup that emphasise Eco Brand Japan’s circular luxury story
- expand the shared stylesheet with gradients, refined card layouts, outline button variants, and updated component styling for the new layout

## Testing
- Manual QA in browser

------
https://chatgpt.com/codex/tasks/task_e_68dfbe238b74832083f205358753444c