### PR TITLE
Streamline homepage call-to-actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,6 @@
               We restore and reintroduce rare designer handbags so they can continue their storied journeys—authentically, responsibly and beautifully.
             </p>
             <div class="hero-actions">
-              <a class="button" href="#offers">Partner with Us</a>
               <a class="button button-outline" href="#values">Explore Our Promise</a>
             </div>
             <ul class="hero-highlights">
@@ -120,7 +119,6 @@
               Our multilingual specialists authenticate, restore and prepare every item before it meets its next guardian. The result is a collection that marries rarity with responsibility, inviting you to invest in fashion history with confidence.
             </p>
             <div class="about-actions">
-              <a class="button" href="career.html">Meet the Team</a>
               <a class="button button-outline" href="#gallery">View Highlights</a>
             </div>
           </div>
@@ -197,7 +195,6 @@
                 <li>In-house photography and catalogues ready for market.</li>
                 <li>Restoration, authentication and logistics handled end-to-end.</li>
               </ul>
-              <a class="text-link" href="mailto:info@ecobrandjapan.com">Share Your Collection</a>
             </article>
             <article class="offer">
               <h3>For Distributors</h3>
@@ -206,7 +203,6 @@
                 <li>Personalised curation and merchandising insights.</li>
                 <li>Consignment options for flagship boutiques and marketplaces.</li>
               </ul>
-              <a class="text-link" href="mailto:info@ecobrandjapan.com">Connect with Our Concierge</a>
             </article>
           </div>
         </div>
@@ -229,7 +225,6 @@
                 alt="Gray Hermès Birkin bag on display"
                 loading="lazy"
               />
-              <figcaption>Hermès Birkin 30 Gris Tourterelle</figcaption>
             </figure>
             <figure class="gallery-item">
               <img
@@ -237,7 +232,6 @@
                 alt="Black YSL bags from a marketing shoot"
                 loading="lazy"
               />
-              <figcaption>Saint Laurent classics prepared for livestream retail</figcaption>
             </figure>
           </div>
         </div>
@@ -248,12 +242,11 @@
           <div>
             <h2>Let&#39;s Shape the Future of Sustainable Luxury</h2>
             <p>
-              Partner with Eco Brand Japan to breathe new life into storied accessories—or join our team to craft memorable client experiences.
+              Join the Eco Brand Japan team to craft memorable client experiences and advance circular luxury.
             </p>
           </div>
           <div class="cta-actions">
-            <a class="button" href="mailto:info@ecobrandjapan.com">Start a Conversation</a>
-            <a class="button button-outline" href="career.html">View Careers</a>
+            <a class="button" href="career.html">View Careers</a>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- remove supplier outreach buttons from the hero, about, and offers sections
- simplify the highlights gallery by dropping photo captions
- focus the sustainable luxury banner copy on careers with a single call-to-action button

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfca380bf883209353626d913bcccc