### PR TITLE
Center Japanese offers and gallery headings

### DIFF
--- a/ja/index.html
+++ b/ja/index.html
@@ -145,7 +145,9 @@
     <!-- Services/Offers section -->
     <section id="offers" class="offers">
       <div class="container offers-container">
-          <h2>How We Work</h2>
+          <div class="offers-header">
+            <h2>How We Work</h2>
+          </div>
           <div class="offers-grid">
             <div class="offer">
               <h3>サプライヤーの方へ</h3>
@@ -170,7 +172,9 @@
     <!-- Gallery section to showcase product highlights -->
     <section class="gallery">
       <div class="container gallery-container">
-        <h2>Highlights</h2>
+        <div class="gallery-header">
+          <h2>Highlights</h2>
+        </div>
         <div class="gallery-grid">
           <div class="gallery-item">
             <img


### PR DESCRIPTION
## Summary
- wrap the Japanese offers and gallery headings with their shared header containers so they use the centered styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfd5d8f21c8320a8e063df0e92e2e4