### PR TITLE
Reorder highlight gallery into two rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,6 +238,34 @@
                 loading="lazy"
               />
             </figure>
+            <figure class="gallery-item">
+              <img
+                src="images/lady_dior.jpg"
+                alt="Lady Dior bag with gold hardware on marble"
+                loading="lazy"
+              />
+            </figure>
+            <figure class="gallery-item">
+              <img
+                src="images/pink_chanel.jpg"
+                alt="Pink Chanel classic flap bag resting on chair"
+                loading="lazy"
+              />
+            </figure>
+            <figure class="gallery-item">
+              <img
+                src="images/pink_gucci.jpg"
+                alt="Gucci Marmont bag and accessories in soft pink hues"
+                loading="lazy"
+              />
+            </figure>
+            <figure class="gallery-item">
+              <img
+                src="images/pink_saigon.jpg"
+                alt="Pink Hermès Kelly bag styled with silk scarf"
+                loading="lazy"
+              />
+            </figure>
           </div>
         </div>
       </section>

--- a/style.css
+++ b/style.css
@@ -615,6 +615,12 @@ section {
   gap: 24px;
 }
 
+@media (min-width: 900px) {
+  .gallery-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
 .gallery-item {
   overflow: hidden;
   border-radius: 20px;


### PR DESCRIPTION
## Summary
- arrange the highlight gallery into two rows with Lady Dior joining the top row
- feature the trio of pink bags together on the lower row for cohesive styling
- enforce a three-column desktop layout so the grid reliably renders as two lines

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3572ce0d483209cfc126e3e3404bf