### PR TITLE
Restore English hero copy and expand Japanese highlights

### DIFF
--- a/ja/index.html
+++ b/ja/index.html
@@ -84,16 +84,25 @@
     </header>
 
     <!-- Hero section with background image from Marketing folder -->
-    <section class="hero hero-ja">
+    <section class="hero hero-home">
       <!-- Background image inserted as img so that mobile browsers reliably load it -->
       <img class="hero-bg" src="../images/8.jpg" alt="Luxury flatlay background" />
       <div class="hero-overlay" aria-hidden="true"></div>
-      <div class="hero-content">
-        <div class="hero-headline">
-          <h1>Sustainable Luxury Reimagined</h1>
-          <p class="hero-subtitle">
-            誠実なまなざしで、ブランドバッグに新しい命と循環の未来を。
+      <div class="container hero-content">
+        <div class="hero-intro">
+          <span class="hero-tag">Circular luxury from Tokyo</span>
+          <h1>Sustainable Luxury, Curated With Intention</h1>
+          <p>
+            We restore and reintroduce rare designer handbags so they can continue their storied journeys—authentically, responsibly and beautifully.
           </p>
+          <div class="hero-actions">
+            <a class="button button-outline" href="#values">Explore Our Promise</a>
+          </div>
+          <ul class="hero-highlights">
+            <li><span>12+</span> years curating iconic maisons</li>
+            <li><span>40k</span> authenticated pieces circulated</li>
+            <li><span>Global</span> network of trusted partners</li>
+          </ul>
         </div>
       </div>
     </section>
@@ -178,20 +187,52 @@
     <section class="gallery">
       <div class="container gallery-container">
         <div class="gallery-header">
-          <h2>Highlights</h2>
+          <span class="section-tag">Highlights</span>
+          <h2>Stories Preserved in Every Detail</h2>
+          <p>
+            Explore a glimpse of the pieces we carefully reintroduce to collectors and connoisseurs worldwide.
+          </p>
         </div>
         <div class="gallery-grid">
           <div class="gallery-item">
             <img
               src="../images/IMG_0758-Edit.jpg"
-              alt="Gray Birkin"
+              alt="Gray Hermès Birkin bag on display"
               loading="lazy"
             />
           </div>
           <div class="gallery-item">
             <img
               src="../images/IMG_9065.jpg"
-              alt="Two black YSL bags from Marketing folder"
+              alt="Black YSL bags from a marketing shoot"
+              loading="lazy"
+            />
+          </div>
+          <div class="gallery-item">
+            <img
+              src="../images/lady_dior.jpg"
+              alt="Lady Dior bag with gold hardware on marble"
+              loading="lazy"
+            />
+          </div>
+          <div class="gallery-item">
+            <img
+              src="../images/pink_chanel.jpg"
+              alt="Pink Chanel classic flap bag resting on chair"
+              loading="lazy"
+            />
+          </div>
+          <div class="gallery-item">
+            <img
+              src="../images/pink_gucci.jpg"
+              alt="Gucci Marmont bag and accessories in soft pink hues"
+              loading="lazy"
+            />
+          </div>
+          <div class="gallery-item">
+            <img
+              src="../images/pink_saigon.jpg"
+              alt="Pink Hermès Kelly bag styled with silk scarf"
               loading="lazy"
             />
           </div>


### PR DESCRIPTION
## Summary
- revert the Japanese hero headline, tagline, copy, and CTA to the English wording for consistency
- expand the Japanese highlights gallery to six items and mirror the English section structure and captions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e35aa634e48320bc229430b8c00c06