### PR TITLE
Update displayed site statistics: pieces 150k→65k and specialists 50→20

### DIFF
--- a/compiled/src/Hero.js
+++ b/compiled/src/Hero.js
@@ -100,7 +100,7 @@ function Hero() {
     className: "hero-stat"
   }, React.createElement("div", {
     className: "n"
-  }, "150k"), React.createElement("div", {
+  }, "65k"), React.createElement("div", {
     className: "l"
   }, copy.pieces)), React.createElement("div", {
     className: "hero-stat"

--- a/compiled/src/about/AboutImpact.js
+++ b/compiled/src/about/AboutImpact.js
@@ -10,7 +10,7 @@ function AboutImpact() {
     note: '2012年から東京を拠点に展開'
   }, {
     k: '循環したアイテム',
-    v: React.createElement(React.Fragment, null, "150", React.createElement("em", null, "k")),
+    v: React.createElement(React.Fragment, null, "65", React.createElement("em", null, "k")),
     note: 'バッグ、革小物、アクセサリーに次の章を'
   }, {
     k: '取り扱いメゾン',
@@ -28,7 +28,7 @@ function AboutImpact() {
     note: 'Since 2012, from Tokyo to the world'
   }, {
     k: 'Pieces circulated',
-    v: React.createElement(React.Fragment, null, "150", React.createElement("em", null, "k")),
+    v: React.createElement(React.Fragment, null, "65", React.createElement("em", null, "k")),
     note: 'Handbags, SLG and accessories given a second chapter'
   }, {
     k: 'Maisons curated',

--- a/compiled/src/about/AboutTeam.js
+++ b/compiled/src/about/AboutTeam.js
@@ -63,7 +63,7 @@ function AboutTeam() {
     className: "atelier-number"
   }, React.createElement("div", {
     className: "n"
-  }, "50"), React.createElement("div", {
+  }, "20"), React.createElement("div", {
     className: "n-caption"
   }, React.createElement("span", {
     className: "plus"

--- a/src/Hero.jsx
+++ b/src/Hero.jsx
@@ -88,7 +88,7 @@ function Hero() {
             <div className="l">{copy.years}</div>
           </div>
           <div className="hero-stat">
-            <div className="n">150k</div>
+            <div className="n">65k</div>
             <div className="l">{copy.pieces}</div>
           </div>
           <div className="hero-stat">

--- a/src/about/AboutImpact.jsx
+++ b/src/about/AboutImpact.jsx
@@ -3,13 +3,13 @@ function AboutImpact() {
   const stats = isJp
     ? [
         { k: 'キュレーション年数', v: <>12<span className="plus">+</span></>, note: '2012年から東京を拠点に展開' },
-        { k: '循環したアイテム', v: <>150<em>k</em></>, note: 'バッグ、革小物、アクセサリーに次の章を' },
+        { k: '循環したアイテム', v: <>65<em>k</em></>, note: 'バッグ、革小物、アクセサリーに次の章を' },
         { k: '取り扱いメゾン', v: <>28</>, note: 'Hermès、Chanelから希少なメゾンまで' },
         { k: '対応言語', v: <>6</>, note: 'English · 日本語 · 中文 · Español · Français · Tagalog' },
       ]
     : [
         { k: 'Years curating', v: <>12<span className="plus">+</span></>, note: 'Since 2012, from Tokyo to the world' },
-        { k: 'Pieces circulated', v: <>150<em>k</em></>, note: 'Handbags, SLG and accessories given a second chapter' },
+        { k: 'Pieces circulated', v: <>65<em>k</em></>, note: 'Handbags, SLG and accessories given a second chapter' },
         { k: 'Maisons curated', v: <>28</>, note: 'From Hermès and Chanel to rarer houses' },
         { k: 'Languages spoken', v: <>6</>, note: 'English · 日本語 · 中文 · Español · Français · Tagalog' },
       ];

--- a/src/about/AboutTeam.jsx
+++ b/src/about/AboutTeam.jsx
@@ -68,7 +68,7 @@ function AboutTeam() {
 
         <div className="atelier-number-row">
           <window.FadeUp delay={120} className="atelier-number">
-            <div className="n">50</div>
+            <div className="n">20</div>
             <div className="n-caption">
               <span className="plus">+</span>
               <div>


### PR DESCRIPTION
### Motivation
- Correct public-facing metrics to reflect updated counts for circulated pieces and in-house specialists.

### Description
- Updated the hero stats in `src/Hero.jsx` and the compiled output to change the pieces count from `150k` to `65k`.
- Updated the about impact panel in `src/about/AboutImpact.jsx` and the compiled output to change "Pieces circulated" from `150k` to `65k`.
- Updated the atelier team count in `src/about/AboutTeam.jsx` and the compiled output to change specialists on staff from `50` to `20`.
- Regenerated compiled artifacts under `compiled/src/` to reflect the source changes.

### Testing
- Ran `npm run build` to regenerate compiled files and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec0b36b7e88330af894980254c88ed)