### PR TITLE
Change About Team slogan to "twenty hands, one standard"

### DIFF
--- a/compiled/src/about/AboutTeam.js
+++ b/compiled/src/about/AboutTeam.js
@@ -52,7 +52,7 @@ function AboutTeam() {
     className: "atelier-eyebrow"
   }, React.createElement("span", {
     className: "dot"
-  }), React.createElement("span", null, isJp ? '五十の手、ひとつの基準' : 'Fifty hands, one standard'))), React.createElement(window.FadeUp, {
+  }), React.createElement("span", null, isJp ? '五十の手、ひとつの基準' : 'twenty hands, one standard'))), React.createElement(window.FadeUp, {
     delay: 60
   }, React.createElement("h2", {
     className: "atelier-headline"

--- a/compiled/src/about/AboutTeam.js
+++ b/compiled/src/about/AboutTeam.js
@@ -52,7 +52,7 @@ function AboutTeam() {
     className: "atelier-eyebrow"
   }, React.createElement("span", {
     className: "dot"
-  }), React.createElement("span", null, isJp ? '五十の手、ひとつの基準' : 'twenty hands, one standard'))), React.createElement(window.FadeUp, {
+  }), React.createElement("span", null, isJp ? '二十の手、ひとつの基準' : 'twenty hands, one standard'))), React.createElement(window.FadeUp, {
     delay: 60
   }, React.createElement("h2", {
     className: "atelier-headline"

--- a/src/about/AboutTeam.jsx
+++ b/src/about/AboutTeam.jsx
@@ -56,7 +56,7 @@ function AboutTeam() {
         <window.FadeUp>
           <div className="atelier-eyebrow">
             <span className="dot"></span>
-            <span>{isJp ? '五十の手、ひとつの基準' : 'Fifty hands, one standard'}</span>
+            <span>{isJp ? '五十の手、ひとつの基準' : 'twenty hands, one standard'}</span>
           </div>
         </window.FadeUp>
 

--- a/src/about/AboutTeam.jsx
+++ b/src/about/AboutTeam.jsx
@@ -56,7 +56,7 @@ function AboutTeam() {
         <window.FadeUp>
           <div className="atelier-eyebrow">
             <span className="dot"></span>
-            <span>{isJp ? '五十の手、ひとつの基準' : 'twenty hands, one standard'}</span>
+            <span>{isJp ? '二十の手、ひとつの基準' : 'twenty hands, one standard'}</span>
           </div>
         </window.FadeUp>
 


### PR DESCRIPTION
### Motivation
- Update the About Team eyebrow copy to match the requested branding change from "Fifty hands, one standard" to "twenty hands, one standard".

### Description
- Replaced the English phrase in `src/about/AboutTeam.jsx` to `twenty hands, one standard`.
- Kept compiled output in sync by updating `compiled/src/about/AboutTeam.js` with the same copy change.
- Persisted the edits in a commit with message `Update About Team slogan to twenty hands`.

### Testing
- No automated tests were run for this copy-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edf25e75dc8330b6d7b1862cb2b0d7)